### PR TITLE
Remove the command to clean at deploy time

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,6 @@
 {
   "scripts": {
-    "deploy": "npm run deploy:clean && npm run deploy:build",
-    "deploy:clean": "find . -type f -name 'src.*.js' -delete && find . -type f -name 'src.*.js.map' -delete",
-    "deploy:build": "$(npm bin)/parcel build --out-dir . --public-url '/my-weight-transitions/' --no-cache src/index.html",
+    "deploy": "$(npm bin)/parcel build --out-dir . --public-url '/my-weight-transitions/' --no-cache src/index.html",
     "dev": "$(npm bin)/parcel --public-url '/my-weight-transitions/' src/index.html",
     "production-test": "npm run production-test:prepare && npm run production-test:run",
     "production-test:prepare": "rm -rf ./dist && rm -rf ./production-test && npm run production-test:prepare:build && mkdir production-test && cp -r dist production-test/my-weight-transitions",


### PR DESCRIPTION
It should not remain old .js/.map files because it is force push.

> Deploying to GitHub Pages uses git push --force to overwrite the history on the target branch

From) https://docs.travis-ci.com/user/deployment/pages/